### PR TITLE
update-generateCFWORKERShortUrl

### DIFF
--- a/src/main/utils/common.ts
+++ b/src/main/utils/common.ts
@@ -201,6 +201,7 @@ const generateCFWORKERShortUrl = async (url: string) => {
   try {
     const res = await axios.post(cfWorkerHost, { url })
     if (res.data?.status === 200 && res.data?.key?.startsWith('/')) {
+      cfWorkerHost = cfWorkerHost.replace(/^(https?:\/\/[^/]+)(\/.*)?$/, '$1')
       return `${cfWorkerHost}${res.data.key}`
     }
   } catch (e: any) {


### PR DESCRIPTION
https://github.com/crazypeace/Url-Shorten-Worker 对原 https://github.com/xyTom/Url-Shorten-Worker 的短链接功能进行了扩充，添加了“秘密path”功能，只有访问这个path才显示使用页面。
此更新添加对“秘密path”功能的兼容